### PR TITLE
Replace react-router-dom with react-router

### DIFF
--- a/lemonade-stand/package-lock.json
+++ b/lemonade-stand/package-lock.json
@@ -18,7 +18,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
-        "react-router-dom": "^7.5.2",
+        "react-router": "^7.5.2",
         "react-scripts": "5.0.1",
         "supabase": "^2.22.4",
         "web-vitals": "^2.1.4"
@@ -16072,22 +16072,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.2.tgz",
-      "integrity": "sha512-yk1XW8Fj7gK7flpYBXF3yzd2NbX6P7Kxjvs2b5nu1M04rb5pg/Zc4fGdBNTeT4eDYL2bvzWNyKaIMJX/RKHTTg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.5.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-router/node_modules/cookie": {

--- a/lemonade-stand/package.json
+++ b/lemonade-stand/package.json
@@ -14,7 +14,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",
-    "react-router-dom": "^7.5.2",
+    "react-router": "^7.5.2",
     "react-scripts": "5.0.1",
     "supabase": "^2.22.4",
     "web-vitals": "^2.1.4"

--- a/lemonade-stand/src/App.jsx
+++ b/lemonade-stand/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router';
 
 // Get the base URL from the import.meta.env (provided by Vite)
 const BASE_URL = import.meta.env.BASE_URL || '/';

--- a/lemonade-stand/src/App.test.jsx
+++ b/lemonade-stand/src/App.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from './test-utils';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import App from './App';
 
 test('renders the app with home page', () => {

--- a/lemonade-stand/src/components/auth/ProtectedRoute.jsx
+++ b/lemonade-stand/src/components/auth/ProtectedRoute.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext';
 
 /**

--- a/lemonade-stand/src/components/auth/ProtectedRoute.test.jsx
+++ b/lemonade-stand/src/components/auth/ProtectedRoute.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '../../test-utils';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import ProtectedRoute from './ProtectedRoute';
 import { mockAuthContextValues } from '../../test-utils';
 

--- a/lemonade-stand/src/components/layout/MainLayout.jsx
+++ b/lemonade-stand/src/components/layout/MainLayout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext';
 import { signOut } from '../../api/supabaseApi';
 

--- a/lemonade-stand/src/pages/HomePage.jsx
+++ b/lemonade-stand/src/pages/HomePage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MapPage } from '../components/map';
 import { useAuth } from '../contexts/AuthContext';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 /**
  * Home page component that displays the map of lemonade stands

--- a/lemonade-stand/src/pages/LoginPage.jsx
+++ b/lemonade-stand/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AuthForm } from '../components/auth';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 /**
  * Login page component

--- a/lemonade-stand/src/pages/NotFoundPage.jsx
+++ b/lemonade-stand/src/pages/NotFoundPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button } from '../components/ui';
 
 /**

--- a/lemonade-stand/src/pages/ProductDetailPage.jsx
+++ b/lemonade-stand/src/pages/ProductDetailPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useAuth } from '../contexts/AuthContext';
 import { 
   getStandById,

--- a/lemonade-stand/src/pages/RegisterPage.jsx
+++ b/lemonade-stand/src/pages/RegisterPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AuthForm } from '../components/auth';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 /**
  * Register page component

--- a/lemonade-stand/src/pages/SellerDashboardPage.jsx
+++ b/lemonade-stand/src/pages/SellerDashboardPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { getUserStands, createStand } from '../api/supabaseApi';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button, Alert } from '../components/ui';
 
 /**

--- a/lemonade-stand/src/pages/StandDetailPage.jsx
+++ b/lemonade-stand/src/pages/StandDetailPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useAuth } from '../contexts/AuthContext';
 import { 
   getStandById, 

--- a/lemonade-stand/src/test-utils.jsx
+++ b/lemonade-stand/src/test-utils.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render as rtlRender } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { AuthProvider } from './contexts/AuthContext';
 import { StandProvider } from './contexts/StandContext';
 import { GeolocationProvider } from './contexts/GeolocationContext';

--- a/lemonade-stand/src/tests/integration/AuthFlow.test.jsx
+++ b/lemonade-stand/src/tests/integration/AuthFlow.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '../../test-utils';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import App from '../../App';
 import { signIn, signUp, signOut } from '../../api/supabaseApi';
 

--- a/lemonade-stand/src/tests/integration/DataPersistence.test.jsx
+++ b/lemonade-stand/src/tests/integration/DataPersistence.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '../../test-utils';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import App from '../../App';
 import { 
   signIn, 

--- a/lemonade-stand/src/tests/integration/StandManagement.test.jsx
+++ b/lemonade-stand/src/tests/integration/StandManagement.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '../../test-utils';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import App from '../../App';
 import { 
   getUserStands, 

--- a/lemonade-stand/vite.config.js
+++ b/lemonade-stand/vite.config.js
@@ -72,7 +72,7 @@ export default defineConfig({
       output: {
         // Chunk files by type
         manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-react': ['react', 'react-dom', 'react-router'],
           'vendor-leaflet': ['leaflet', 'react-leaflet'],
           'vendor-supabase': ['@supabase/supabase-js'],
           'vendor-ui': ['./src/components/ui/index.js'],
@@ -108,6 +108,6 @@ export default defineConfig({
     allowedHosts: true,
   },
   optimizeDeps: {
-    include: ['react', 'react-dom', 'react-router-dom', 'leaflet', 'react-leaflet'],
+    include: ['react', 'react-dom', 'react-router', 'leaflet', 'react-leaflet'],
   },
 });


### PR DESCRIPTION
This PR updates all imports from react-router-dom to react-router as the former is now deprecated in favor of the latter. Changes include:

- Updated package.json to use react-router instead of react-router-dom
- Updated all import statements in JSX files to import from react-router instead of react-router-dom
- Updated vite.config.js to reference react-router instead of react-router-dom in the build configuration

All components continue to work as expected with the new imports.