### PR TITLE
Fix infinite update loop in Map component

### DIFF
--- a/lemonade-stand/src/components/map/Map.jsx
+++ b/lemonade-stand/src/components/map/Map.jsx
@@ -89,7 +89,7 @@ const UserLocationMarker = memo(({ showUserLocation, onUserLocationFound }) => {
         }).addTo(map);
       }
     }
-  }, [position, map, showUserLocation]); // Use position instead of location to avoid circular dependency
+  }, [location, map, showUserLocation]); // Use location instead of position to avoid circular dependency
   
   // Separate useEffect for notifying parent to prevent infinite loops
   useEffect(() => {


### PR DESCRIPTION
This PR fixes the "Maximum update depth exceeded" error in the Map component by correcting the dependency array in the useEffect hook. The issue was caused by including `position` in the dependency array of the same useEffect that was setting the position state, creating an infinite update loop. Changed the dependency to use `location` instead of `position` to break the circular dependency.