### PR TITLE
Fix map markers and login redirection issues

### DIFF
--- a/lemonade-stand/src/components/auth/AuthForm.jsx
+++ b/lemonade-stand/src/components/auth/AuthForm.jsx
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import { signIn, signUp, signOut } from '../../api/supabaseApi';
 import { useAuth } from '../../contexts/AuthContext';
 import { Form, Button, Alert } from '../ui';
+import { useNavigate } from 'react-router-dom';
 
 const AuthForm = ({ initialMode = 'login' }) => {
   const { user, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
   const [mode, setMode] = useState(initialMode); // 'login' or 'register'
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -43,6 +45,8 @@ const AuthForm = ({ initialMode = 'login' }) => {
         }
         
         setSuccess('Logged in successfully!');
+        // Redirect to dashboard after successful login
+        navigate('/seller/dashboard');
       } else {
         // Register
         const { data, error } = await signUp(

--- a/lemonade-stand/src/components/map/Map.jsx
+++ b/lemonade-stand/src/components/map/Map.jsx
@@ -24,7 +24,7 @@ L.Icon.Default.mergeOptions({
 // Custom lemonade stand marker icon
 const createLemonadeIcon = () =>
   new L.Icon({
-    iconUrl: "/public/images/markers/lemonade-marker.svg",
+    iconUrl: "/images/markers/lemonade-marker.svg",
     iconSize: [40, 48],
     iconAnchor: [20, 48],
     popupAnchor: [0, -48],


### PR DESCRIPTION
This PR fixes two issues:

1. Map markers not rendering: Fixed the incorrect paths to marker icons in Map.jsx
   - Changed lemonade stand marker path from "/public/images/markers/lemonade-marker.svg" to "/images/markers/lemonade-marker.svg"

2. Login redirection issue: Added navigation to dashboard after successful login
   - Imported useNavigate from react-router-dom
   - Added navigation to "/seller/dashboard" after successful login

These changes ensure that:
- Users can see their location and lemonade stand markers on the map
- Users are properly redirected to the dashboard after logging in