### PR TITLE
Fix: Add missing Form.Text component to resolve blank page issue

### DIFF
--- a/lemonade-stand/src/components/ui/Form.jsx
+++ b/lemonade-stand/src/components/ui/Form.jsx
@@ -330,6 +330,22 @@ Radio.propTypes = {
   className: PropTypes.string,
 };
 
+/**
+ * Form Text component for help text
+ */
+const FormText = ({ children, className = '', ...props }) => {
+  return (
+    <p className={`text-sm text-gray-600 mt-1 ${className}`} {...props}>
+      {children}
+    </p>
+  );
+};
+
+FormText.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
 // Export all components
 Form.Group = FormGroup;
 Form.Label = FormLabel;
@@ -338,5 +354,6 @@ Form.Textarea = Textarea;
 Form.Select = Select;
 Form.Checkbox = Checkbox;
 Form.Radio = Radio;
+Form.Text = FormText;
 
 export default Form;


### PR DESCRIPTION
This PR fixes the issue where clicking on "Edit Details" on the Stand Details card results in a blank page.

## Problem
The Form.Text component was being used in the StandDetailPage.jsx file but was not defined in the Form.jsx component file.

## Solution
Added the missing Form.Text component to the Form.jsx file and exported it properly.

## Testing
Built and tested the application to verify that the "Edit Details" functionality now works correctly.