### PR TITLE
Rename app to Lemonade Map and fix geolocation HTTPS issue

### DIFF
--- a/lemonade-stand/index.html
+++ b/lemonade-stand/index.html
@@ -7,14 +7,14 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Lemonade Stand - A platform for managing lemonade stands and their products"
+      content="Lemonade Map - A platform for managing lemonade stands and their products"
     />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="format-detection" content="telephone=no" />
     <link rel="apple-touch-icon" href="./logo192.png" />
     <link rel="manifest" href="./manifest.json" />
-    <title>Lemonade Stand</title>
+    <title>Lemonade Map</title>
     
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">

--- a/lemonade-stand/src/components/layout/MainLayout.jsx
+++ b/lemonade-stand/src/components/layout/MainLayout.jsx
@@ -28,7 +28,7 @@ const MainLayout = ({ children }) => {
         <div className="max-w-6xl mx-auto px-4">
           <div className="flex items-center justify-between">
             <Link to="/" className="flex items-center">
-              <h1 className="text-2xl md:text-4xl font-display text-gray-800">Lemonade Stand</h1>
+              <h1 className="text-2xl md:text-4xl font-display text-gray-800">Lemonade Map</h1>
             </Link>
             
             <nav className="hidden md:flex items-center space-x-6">
@@ -96,7 +96,7 @@ const MainLayout = ({ children }) => {
         <div className="max-w-6xl mx-auto px-4">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <div className="mb-4 md:mb-0">
-              <h2 className="text-xl font-display">Lemonade Stand</h2>
+              <h2 className="text-xl font-display">Lemonade Map</h2>
               <p className="text-gray-400">Find and manage lemonade stands</p>
             </div>
             
@@ -114,7 +114,7 @@ const MainLayout = ({ children }) => {
           </div>
           
           <div className="mt-8 pt-8 border-t border-gray-700 text-center text-gray-400">
-            <p>&copy; {new Date().getFullYear()} Lemonade Stand. All rights reserved.</p>
+            <p>&copy; {new Date().getFullYear()} Lemonade Map. All rights reserved.</p>
           </div>
         </div>
       </footer>

--- a/lemonade-stand/src/services/geolocationService.jsx
+++ b/lemonade-stand/src/services/geolocationService.jsx
@@ -22,9 +22,11 @@ export const isSecureContext = () => {
   
   // In production, check for secure context
   return window.isSecureContext || 
+         window.location.protocol === 'https:' ||
          window.location.hostname === 'localhost' || 
          window.location.hostname === '127.0.0.1' ||
-         window.location.hostname.includes('all-hands.dev'); // Allow our development domain
+         window.location.hostname.includes('all-hands.dev') ||
+         window.location.hostname.includes('prod-runtime.all-hands.dev'); // Allow our development domains
 };
 
 /**

--- a/lemonade-stand/vite.config.js
+++ b/lemonade-stand/vite.config.js
@@ -103,8 +103,8 @@ export default defineConfig({
     },
     // Add historyApiFallback for SPA routing
     historyApiFallback: true,
-    // We'll handle HTTPS differently - removing this for now
-    https: false,
+    // Enable HTTPS to fix geolocation issues
+    https: true,
   },
   preview: {
     host: '0.0.0.0',
@@ -112,8 +112,8 @@ export default defineConfig({
     allowedHosts: true,
     // Add historyApiFallback for SPA routing
     historyApiFallback: true,
-    // We'll handle HTTPS differently - removing this for now
-    https: false,
+    // Enable HTTPS to fix geolocation issues
+    https: true,
   },
   optimizeDeps: {
     include: ['react', 'react-dom', 'react-router', 'leaflet', 'react-leaflet'],


### PR DESCRIPTION
This PR makes the following changes:

1. Changes the app name from "Lemonade Stand" to "Lemonade Map" in:
   - MainLayout.jsx header and footer
   - index.html title and meta description

2. Fixes the geolocation error by:
   - Adding HTTPS protocol check in isSecureContext function
   - Adding support for prod-runtime.all-hands.dev domain
   - Enabling HTTPS in Vite configuration

User-created stands continue to be named "lemonade stands" as required.