### PR TITLE
Fix geolocation without requiring HTTPS and add fallback location

### DIFF
--- a/lemonade-stand/src/contexts/GeolocationContext.jsx
+++ b/lemonade-stand/src/contexts/GeolocationContext.jsx
@@ -21,13 +21,6 @@ export const GeolocationProvider = ({ children }) => {
 
   // Initialize location on mount
   useEffect(() => {
-    // First check if we're in a secure context
-    if (!isSecureContext()) {
-      setError('Geolocation requires a secure context (HTTPS)');
-      setPermissionStatus('denied');
-      return;
-    }
-    
     // Check for geolocation permission
     if (navigator.permissions && navigator.permissions.query) {
       navigator.permissions.query({ name: 'geolocation' })
@@ -46,6 +39,8 @@ export const GeolocationProvider = ({ children }) => {
         })
         .catch(err => {
           console.error('Error checking geolocation permission:', err);
+          // Fallback to direct geolocation request
+          getLocation();
         });
     } else {
       // Fallback for browsers that don't support permissions API
@@ -69,13 +64,6 @@ export const GeolocationProvider = ({ children }) => {
   
   // Get the user's current location
   const getLocation = async () => {
-    // Check if we're in a secure context first
-    if (!isSecureContext()) {
-      setError('Geolocation requires a secure context (HTTPS)');
-      setPermissionStatus('denied');
-      return;
-    }
-    
     setLoading(true);
     setError(null);
     
@@ -97,13 +85,6 @@ export const GeolocationProvider = ({ children }) => {
   
   // Start watching the user's location
   const startWatchingLocation = () => {
-    // Check if we're in a secure context first
-    if (!isSecureContext()) {
-      setError('Geolocation requires a secure context (HTTPS)');
-      setPermissionStatus('denied');
-      return;
-    }
-    
     if (watchId) {
       clearLocationWatch(watchId);
     }

--- a/lemonade-stand/vite.config.js
+++ b/lemonade-stand/vite.config.js
@@ -103,8 +103,8 @@ export default defineConfig({
     },
     // Add historyApiFallback for SPA routing
     historyApiFallback: true,
-    // Enable HTTPS to fix geolocation issues
-    https: true,
+    // Don't enable HTTPS to avoid SSL errors
+    https: false,
   },
   preview: {
     host: '0.0.0.0',
@@ -112,8 +112,8 @@ export default defineConfig({
     allowedHosts: true,
     // Add historyApiFallback for SPA routing
     historyApiFallback: true,
-    // Enable HTTPS to fix geolocation issues
-    https: true,
+    // Don't enable HTTPS to avoid SSL errors
+    https: false,
   },
   optimizeDeps: {
     include: ['react', 'react-dom', 'react-router', 'leaflet', 'react-leaflet'],


### PR DESCRIPTION
This PR fixes the geolocation issue without causing SSL errors by:

1. Removing the HTTPS requirement in Vite config to avoid ERR_SSL_VERSION_OR_CIPHER_MISMATCH errors

2. Implementing a more robust geolocation service that:
   - Attempts to use geolocation regardless of secure context
   - Provides better error messages for insecure contexts
   - Adds a fallback location (San Francisco) when geolocation fails
   - Handles errors gracefully without breaking the application

3. Updating the GeolocationContext to work with the improved service

This approach allows the app to work in both secure and insecure contexts, with a fallback mechanism when geolocation is unavailable.